### PR TITLE
Fix: Update backend URL for production deployment

### DIFF
--- a/wait-node copy.html
+++ b/wait-node copy.html
@@ -145,7 +145,7 @@
     // Handle file:// protocol and localhost
     const BACKEND_URL = (!window.location.hostname || window.location.hostname === 'localhost' || window.location.protocol === 'file:')
         ? 'http://localhost:5678' 
-        : 'https://your-backend-url.com'; // Replace with your production backend URL
+        : 'https://taskpages-backend.onrender.com'; // Production backend URL on Render
     const PROCESS_LIBRARY_TYPE = 1018; // custom_item_id for Process Library tasks
 
     // Custom field IDs


### PR DESCRIPTION
## Summary
- Updated backend URL in wait-node copy.html to point to the production Render deployment
- Changed from placeholder URL to https://taskpages-backend.onrender.com
- Maintains localhost:5678 for local development

## Changes
- Modified `wait-node copy.html` line 148 to use the correct production backend URL

## Testing
- Frontend will connect to the deployed Flask backend on Render
- Auto-deploy will update the static site once merged to main

🤖 Generated with [Claude Code](https://claude.ai/code)